### PR TITLE
I had to make some changes to get this to work on Gadi.

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -61,7 +61,7 @@ runspersub: 1
 
 userscripts:
     # Setup land use changes
-    setup: ./scripts/pre.sh work/atmosphere/INPUT/cableCMIP6_LC_1850-2015.nc
+    setup: ./scripts/pre.sh /g/data1a/p66/txz599/data/luc_ssp585/land_use_all_date.nc
 
 stacksize: unlimited
 

--- a/warm-start.sh
+++ b/warm-start.sh
@@ -17,13 +17,13 @@ if [ $source == "CSIRO" ]; then
     user=cm2704
     export expname=HI-08            # Source experiment - PI pre-industrial, HI historical
     export source_year=2015          # Change this to create different ensemble members
-    export csiro_source=/g/data/$project/$user/archive/$expname/restart
+    export csiro_source=/g/data/$project/$user/archive/ACCESS-ESM1-5/$expname/restart
 
     # Call the main warm-start script
     scripts/warm-start-csiro.sh
 
 else
-    
+
     # Payu restart directory to copy
     export payu_source=/scratch/w35/saw562/access-esm/archive/esm-historical/restart001
 


### PR DESCRIPTION
Payu doesn't seem to have land use change files for future scenarios. I pointed the config file to Tilo's land use states for ssp585, since it doesn't really make sense to have the script pointing to historical land use files for a future scenario.

Also the directory for the CSIRO restart files seemed to be missing a subdirectory in the path.